### PR TITLE
Refine NIKON's DeviceInfo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ missing
 Makefile
 Makefile.in
 stamp-h*
+compile

--- a/m4/byteorder.m4
+++ b/m4/byteorder.m4
@@ -218,10 +218,12 @@ if test "$HAVE_LE32TOH" != "1"; then
 /* Define aliases for the standard byte swapping macros */
 /* Arguments to these macros must be properly aligned on natural word */
 /* boundaries in order to work properly on all architectures */
+#ifndef htobe16
 #define htobe16(x) htons(x)
 #define htobe32(x) htonl(x)
 #define be16toh(x) ntohs(x)
 #define be32toh(x) ntohl(x)
+#endif
 
 #define HTOBE16(x) (x) = htobe16(x)
 #define HTOBE32(x) (x) = htobe32(x)
@@ -268,8 +270,10 @@ EOF
 #define LE64TOH(x)      (void) (x)
 
 /* These don't have standard aliases */
+#ifndef htobe64
 #define htobe64(x)      swap64(x)
 #define be64toh(x)      swap64(x)
+#endif
 
 #define HTOBE64(x)      (x) = htobe64(x)
 #define BE64TOH(x)      (x) = be64toh(x)

--- a/src/ptp.h
+++ b/src/ptp.h
@@ -797,6 +797,8 @@ struct _PTPParams {
 };
 
 /* last, but not least - ptp functions */
+uint16_t ptp_transaction (PTPParams* params, PTPContainer* ptp,
+			uint16_t flags, unsigned int sendlen, char** data);
 uint16_t ptp_usb_sendreq	(PTPParams* params, PTPContainer* req);
 uint16_t ptp_usb_senddata	(PTPParams* params, PTPContainer* ptp,
 				unsigned char *data, unsigned int size);

--- a/src/ptp.h
+++ b/src/ptp.h
@@ -183,6 +183,7 @@ typedef struct _PTPUSBEventContainer PTPUSBEventContainer;
 #define PTP_OC_NIKON_SetControlMode	0x90C2
 #define PTP_OC_NIKON_CheckEvent		0x90C7
 #define PTP_OC_NIKON_KeepAlive		0x90C8
+#define PTP_OC_NIKON_GetVendorPropCodes	0x90CA	/* 0 params, data in: hack from libgphoto2 */
 
 /* Proprietary vendor extension operations mask */
 #define PTP_OC_EXTENSION_MASK		0xF000
@@ -806,6 +807,7 @@ uint16_t ptp_usb_event_check	(PTPParams* params, PTPContainer* event);
 uint16_t ptp_usb_event_wait		(PTPParams* params, PTPContainer* event);
 
 uint16_t ptp_getdeviceinfo	(PTPParams* params, PTPDeviceInfo* deviceinfo);
+uint16_t ptp_fixup_deviceinfo (PTPParams* params, PTPDeviceInfo* deviceinfo, int idVendor);
 
 uint16_t ptp_opensession	(PTPParams *params, uint32_t session);
 uint16_t ptp_closesession	(PTPParams *params);
@@ -895,6 +897,7 @@ uint16_t ptp_nikon_directcapture (PTPParams* params, uint32_t unknown);
 uint16_t ptp_nikon_checkevent (PTPParams* params,
 				PTPUSBEventContainer** event, uint16_t* evnum);
 uint16_t ptp_nikon_keepalive (PTPParams* params);
+uint16_t ptp_nikon_get_vendorpropcodes (PTPParams* params, uint16_t **props, unsigned int *size);
 
 
 /* Non PTP protocol functions */

--- a/src/ptpcam.c
+++ b/src/ptpcam.c
@@ -23,6 +23,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <malloc.h>
 #include <getopt.h>
 #include <unistd.h>
 #include <signal.h>
@@ -872,6 +873,8 @@ err:
 	close_camera(&ptp_usb, &params, dev);
 }
 
+void
+nikon_initiate_dc (int busn, int devn, short force);
 void
 nikon_initiate_dc (int busn, int devn, short force)
 {
@@ -2123,7 +2126,8 @@ ptp_transaction_senddata (PTPParams* params, PTPContainer* ptp, unsigned int sen
 	return (ptp_transaction(params, ptp, PTP_DP_SENDDATA, sendlen, &data));
 }
 
-void ptphack()
+void ptphack(void);
+void ptphack(void)
 {
 	PTPParams params={};
 	PTP_USB ptp_usb={};

--- a/src/ptpcam.c
+++ b/src/ptpcam.c
@@ -486,7 +486,7 @@ open_camera (int busn, int devn, short force, PTP_USB *ptp_usb, PTPParams *param
 		close_usb(ptp_usb, *dev);
 		return -1;
 	}
-	hack_deviceinfo(&params->deviceinfo, *dev);
+	ptp_fixup_deviceinfo(params,&params->deviceinfo,(*dev)->descriptor.idVendor); // ignore error. run under orignal deviceinfo.
 	return 0;
 }
 
@@ -496,43 +496,6 @@ close_camera (PTP_USB *ptp_usb, PTPParams *params, struct usb_device *dev)
 	if (ptp_closesession(params)!=PTP_RC_OK)
 		fprintf(stderr,"ERROR: Could not close session!\n");
 	close_usb(ptp_usb, dev);
-}
-
-const static uint16_t nikon_d40_hidden_props[] = {
-	0xd017, 0xd018, 0xd019, 0xd01a, 0xd01b, 0xd01c, 0xd01d, 0xd01f,
-	0xd025, 0xd026, 0xd02a, 0xd02b, 0xd02c, 0xd02d,
-	0xd045,
-	0xd054, 0xd05e, 0xd05f,
-	0xd062, 0xd063, 0xd064, 0xd065, 0xd066, 0xd06b, 0xd06c,
-	0xd084, 0xd08a,
-	0xd090, 0xd091, 0xd092,
-	0xd0e0, 0xd0e1, 0xd0e2, 0xd0e3, 0xd0e4, 0xd0e5, 0xd0e6,
-	0xd100, 0xd101, 0xd102, 0xd103, 0xd104, 0xd105, 0xd108, 0xd109, 0xd10b, 0xd10d, 0xd10e,
-	0xd120, 0xd121, 0xd122, 0xd124, 0xd125, 0xd126,
-	0xd140, 0xd142,
-	0xd160, 0xd161, 0xd163, 0xd164, 0xd165, 0xd167, 0xd16a, 0xd16b, 0xd16d,
-	0xd183,
-	0xd1b0, 0xd1b1, 0xd1b2,
-	0xd1c0, 0xd1c1,
-	0xd1e0, 0xd1e1
-};
-
-void
-hack_deviceinfo(PTPDeviceInfo* deviceinfo, struct usb_device* dev)
-{
-	int i;
-
-	if (deviceinfo->VendorExtensionID==PTP_VENDOR_MICROSOFT &&
-	    dev->descriptor.idVendor==0x4b0 &&
-	    dev->descriptor.idProduct==0x414)
-	{
-		deviceinfo->VendorExtensionID = PTP_VENDOR_NIKON;
-		deviceinfo->DevicePropertiesSupported = realloc(deviceinfo->DevicePropertiesSupported,deviceinfo->DevicePropertiesSupported_len*sizeof(uint16_t) + sizeof(nikon_d40_hidden_props));
-		for (i = 0; i < sizeof(nikon_d40_hidden_props)/sizeof(uint16_t); i++) {
-			deviceinfo->DevicePropertiesSupported[deviceinfo->DevicePropertiesSupported_len] = nikon_d40_hidden_props[i];
-			deviceinfo->DevicePropertiesSupported_len++;
-		}
-	}
 }
 
 void

--- a/src/ptpcam.h
+++ b/src/ptpcam.h
@@ -168,6 +168,5 @@ int usb_get_endpoint_status(PTP_USB* ptp_usb, int ep, uint16_t* status);
 int usb_clear_stall_feature(PTP_USB* ptp_usb, int ep);
 int open_camera (int busn, int devn, short force, PTP_USB *ptp_usb, PTPParams *params, struct usb_device **dev);
 void close_camera (PTP_USB *ptp_usb, PTPParams *params, struct usb_device *dev);
-void hack_deviceinfo(PTPDeviceInfo* deviceinfo, struct usb_device* dev);
 
 #endif /* __PTPCAM_H__ */


### PR DESCRIPTION
I have rewriten your commit 4dc3f92 (D40's DeviceInfo packet) to support any NIKON DSLR.
I have tested for D5000 and D5500 on RaspberryPi2-Raspbian-Jessie.
please check for D40, and merge your master.

my issue is https://github.com/hkuno9000/ptpcam-fork/issues/1
